### PR TITLE
Add ModeSelect scene (🔊/🔇) and conditional background music loading for V3

### DIFF
--- a/src/js/Menu.ts
+++ b/src/js/Menu.ts
@@ -40,7 +40,7 @@ export class Menu extends Phaser.Scene {
         // DRJ- debug
         this.aGrid.placeAtIndex( 60, startBtn );
         startBtn.setInteractive();
-        startBtn.once('pointerdown', () => this.scene.start('playGame'));
+        startBtn.once('pointerdown', () => this.scene.start('modeSelect'));
 
         // options button
         let {x,y} = startBtn.getBottomCenter();

--- a/src/js/ModeSelect.ts
+++ b/src/js/ModeSelect.ts
@@ -1,0 +1,63 @@
+import { config } from './config';
+import { gameSettings } from './game-settings';
+
+export class ModeSelect extends Phaser.Scene {
+    constructor() {
+        super('modeSelect');
+    }
+
+    create() {
+        const centerX = config.width / 2;
+
+        const title = this.add.text(centerX, 30, 'SELECT SOUND', {
+            fontFamily: 'Arial',
+            fontSize: '12px',
+            color: '#ffffff'
+        }).setOrigin(0.5);
+
+        const soundOn = this.add.text(centerX, config.height * 0.33, '🔊', {
+            fontSize: '48px'
+        }).setOrigin(0.5);
+
+        const soundOff = this.add.text(centerX, config.height * 0.66, '🔇', {
+            fontSize: '48px'
+        }).setOrigin(0.5);
+
+        const startWithSound = () => {
+            gameSettings.playMusic = true;
+            this.enterFullscreen();
+            this.scene.start('playGame');
+        };
+
+        const startMuted = () => {
+            gameSettings.playMusic = false;
+            this.enterFullscreen();
+            this.scene.start('playGame');
+        };
+
+        soundOn.setInteractive({ useHandCursor: true });
+        soundOff.setInteractive({ useHandCursor: true });
+
+        soundOn.on('pointerdown', startWithSound);
+        soundOff.on('pointerdown', startMuted);
+
+        this.tweens.add({
+            targets: [soundOn, soundOff],
+            alpha: 0.8,
+            duration: 500,
+            yoyo: true,
+            repeat: -1
+        });
+
+        this.events.once('shutdown', () => {
+            soundOn.off('pointerdown', startWithSound);
+            soundOff.off('pointerdown', startMuted);
+        });
+    }
+
+    private enterFullscreen() {
+        if (!this.scale.isFullscreen) {
+            this.scale.startFullscreen();
+        }
+    }
+}

--- a/src/js/Scene1.ts
+++ b/src/js/Scene1.ts
@@ -321,7 +321,6 @@ export class Scene1 extends Phaser.Scene {
         this.load.audio('audio_beam', [require('../assets/sounds/beam.ogg'), require('../assets/sounds/beam.mp3')]);
         this.load.audio('audio_explosion', [require('../assets/sounds/explosion.ogg'), require('../assets/sounds/explosion.mp3')]);
         this.load.audio('audio_pickup', [require('../assets/sounds/pickup.ogg'), require('../assets/sounds/pickup.mp3')]);
-        this.load.audio( 'music', require('../assets/sounds/title-song-vbr (Mastered with Thunder at 100pct).mp3') );
 
 
         // DRJ- ERROR - `File.js:97 Uncaught TypeError: this.url.indexOf is not a function at JSONFile.File`

--- a/src/js/Scene2.ts
+++ b/src/js/Scene2.ts
@@ -1,6 +1,7 @@
 import {Beam} from './beam.ts';
 import {config} from './config.ts';
 import {gameSettings} from './game-settings.ts';
+import musicTrack from '../assets/sounds/title-song-vbr (Mastered with Thunder at 100pct).mp3';
 import {Explosion} from './explosion.ts'
 import {VirusExplosion} from './virus-explosion.ts'
 import Phaser from 'phaser';
@@ -85,9 +86,19 @@ export class Scene2 extends Phaser.Scene {
             delay: 0
         };
 
-        this.music = this.sound.add('music', musicConfig);
-
-        this.music.play();
+        if (gameSettings.playMusic) {
+            if (!this.cache.audio.exists('music')) {
+                this.load.audio('music', musicTrack);
+                this.load.once(Phaser.Loader.Events.COMPLETE, () => {
+                    this.music = this.sound.add('music', musicConfig);
+                    this.music.play();
+                });
+                this.load.start();
+            } else {
+                this.music = this.sound.add('music', musicConfig);
+                this.music.play();
+            }
+        }
 
         this.sound.pauseOnBlur = false;
 

--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -1,5 +1,6 @@
 import {Menu} from './Menu.ts';
 import {Scene2} from './Scene2.ts';
+import {ModeSelect} from './ModeSelect';
 import phaserJuice from './phaserJuicePlugin.min.js';
 
 
@@ -11,7 +12,7 @@ export var config = {
             { key: 'phaserJuice', plugin: phaserJuice, mapping: 'juice' }
         ]
     },
-    scene: [Menu, Scene2],
+    scene: [Menu, ModeSelect, Scene2],
     pixelArt: true,
     scale: {
         mode: Phaser.Scale.FIT,

--- a/src/js/game-settings.ts
+++ b/src/js/game-settings.ts
@@ -1,4 +1,5 @@
 
 export var gameSettings = {
-    playerSpeed: 200
+    playerSpeed: 200,
+    playMusic: true
 };

--- a/src/js/lincoln.ts
+++ b/src/js/lincoln.ts
@@ -76,7 +76,9 @@ export class Lincoln extends BaseEntity {
             return this.scene.juice.spinXTween.restart();
         }
         
-        this.scene.music.setRate( 1.5 );
+        if (this.scene.music) {
+            this.scene.music.setRate( 1.5 );
+        }
         this.boosting = true;
         this.scene.stars.setSpeedY( 425 );
         this.scene.stars.frequency = 50;
@@ -87,7 +89,9 @@ export class Lincoln extends BaseEntity {
             duration: 250,
             repeat: 16,
             onComplete: () => {
-                this.scene.music.setRate( 1 );
+                if (this.scene.music) {
+                    this.scene.music.setRate( 1 );
+                }
 
                 this.scene.stars.setSpeedY({
                     min : 60,


### PR DESCRIPTION
### Motivation
- Implement the V3 flow to present an explicit sound mode selection screen (full‑screen on selection) and allow players to opt out of background music so the game can skip loading the music asset when muted.

### Description
- Added a new scene `ModeSelect` (`src/js/ModeSelect.ts`) that shows top/bottom emoji choices `🔊` / `🔇`, enters fullscreen via `this.scale.startFullscreen()` on selection, and starts `playGame` with the chosen mode.
- Wired the main menu to route through the mode screen by changing the start action in `src/js/Menu.ts` to `this.scene.start('modeSelect')` and registered the scene in `src/js/config.ts`.
- Introduced `gameSettings.playMusic` in `src/js/game-settings.ts` to persist the choice across scenes and changed `Scene2` (`src/js/Scene2.ts`) to only load/play the music when `playMusic` is true using a dynamic loader (imported `musicTrack` and `this.load.audio(...); this.load.start()` when needed).
- Removed the eager music preload from `src/js/Scene1.ts` and guarded music-dependent calls in `src/js/lincoln.ts` so boost effects do not throw when no music instance exists.

### Testing
- Ran `npm install` which completed successfully in this environment. (✅)
- Attempted to produce a build with `npx parcel build ...` but the environment could not fetch `parcel` from the npm registry (403 Forbidden), so a full production bundle was not produced. (⚠️)
- Ran the TypeScript check `npx tsc --noEmit`, which failed due to many pre-existing project type errors not introduced by these changes; the music-mode changes themselves are syntactically integrated. (❌)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fab8897808332b457085f867a34f1)